### PR TITLE
feat: migrazione backend da Supabase a Google Apps Script

### DIFF
--- a/app/src/main/java/com/emanuele/gestionespese/MainActivity.kt
+++ b/app/src/main/java/com/emanuele/gestionespese/MainActivity.kt
@@ -15,8 +15,8 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        val baseUrl = getString(R.string.supabase_url)
-        val apiKey = getString(R.string.supabase_anon_key)
+        val baseUrl = getString(R.string.backend_url)
+        val apiKey = getString(R.string.backend_api_key)
 
         val retrofit = RetrofitProvider.create(baseUrl, apiKey)
         val api = retrofit.create(SupabaseApi::class.java)

--- a/app/src/main/java/com/emanuele/gestionespese/data/model/Spesa.kt
+++ b/app/src/main/java/com/emanuele/gestionespese/data/model/Spesa.kt
@@ -11,41 +11,72 @@ data class SpesaView(
     val tipo: String? = null,
     val mese: Int? = null,
     val anno: Int? = null,
-    @SerializedName("metodo_pagamento")
+    @SerializedName(value = "metodo_pagamento", alternate = ["conto", "conto_id"])
     val metodoPagamento: String? = null,
     @SerializedName("created_at")
     val createdAt: String? = null,
 
-    // nuovi campi dalla VIEW
-    @SerializedName("categoria_link_id")
+    @SerializedName(value = "categoria_link_id", alternate = ["categoria_link"])
     val categoriaLinkId: String? = null,
-    @SerializedName("categoria_id")
+    @SerializedName(value = "categoria_id", alternate = ["categoria"])
     val categoriaId: String? = null,
-    @SerializedName("sottocategoria_id")
+    @SerializedName(value = "sottocategoria_id", alternate = ["sottocategoria"])
     val sottocategoriaId: String? = null,
 
     val categoria: String? = null,
     val sottocategoria: String? = null
 )
 
-// Scrittura: su tabella spese (ID, non nomi)
+// Scrittura app (modello interno)
 data class SpesaUpsert(
     val id: Int? = null,
     val data: String,
     val importo: Double,
     val tipo: String,
-
     val mese: Int,
     val anno: Int,
-
     @SerializedName("categoria_link_id")
     val categoriaLinkId: String,
-
     @SerializedName("metodo_pagamento")
     val metodoPagamento: String,
-
     @SerializedName("descrizione")
     val note: String? = null
+)
+
+// Scrittura verso Apps Script (payload HTTP)
+data class SpesaUpsertRequest(
+    val resource: String = "spesa",
+    val id: Int? = null,
+    @SerializedName("utente_id") val utenteId: String = "2 - A.BERTOLI",
+    @SerializedName("conto_id") val contoId: String,
+    val data: String,
+    val importo: Double,
+    val tipo: String,
+    val categoria: String,
+    val sottocategoria: String,
+    val descrizione: String?
+)
+
+data class UpdateSpesaRequest(
+    val resource: String = "spesa_update",
+    val id: Int,
+    @SerializedName("conto_id") val contoId: String,
+    val data: String,
+    val importo: Double,
+    val tipo: String,
+    val categoria: String,
+    val sottocategoria: String,
+    val descrizione: String?
+)
+
+data class DeleteSpesaRequest(
+    val resource: String = "spesa_delete",
+    val id: Int
+)
+
+data class InsertSpesaResponse(
+    val id: Int? = null,
+    val ok: Boolean? = null
 )
 
 data class Categoria(
@@ -70,28 +101,4 @@ data class LinkSottoRow(
 
 data class LinkIdRow(
     val id: String
-)
-
-data class RpcInsertSpesaRequest(
-    @SerializedName("p_data") val data: String,                 // "YYYY-MM-DD"
-    @SerializedName("p_descrizione") val descrizione: String?,   // nullable
-    @SerializedName("p_importo") val importo: Double,
-    @SerializedName("p_tipo") val tipo: String,
-    @SerializedName("p_mese") val mese: Int,
-    @SerializedName("p_anno") val anno: Int,
-    @SerializedName("p_metodo_pagamento") val metodoPagamento: String,
-    @SerializedName("p_categoria_link_id") val categoriaLinkId: String // UUID string
-)
-
-// Se vuoi leggere la riga che torna dalla function (opzionale)
-data class SpesaRow(
-    val id: Int,
-    val data: String?,
-    val descrizione: String?,
-    val importo: Double?,
-    val tipo: String?,
-    val mese: Int?,
-    val anno: Int?,
-    @SerializedName("metodo_pagamento") val metodoPagamento: String?,
-    @SerializedName("categoria_link_id") val categoriaLinkId: String?
 )

--- a/app/src/main/java/com/emanuele/gestionespese/data/remote/SupabaseApi.kt
+++ b/app/src/main/java/com/emanuele/gestionespese/data/remote/SupabaseApi.kt
@@ -2,107 +2,48 @@ package com.emanuele.gestionespese.data.remote
 
 import com.emanuele.gestionespese.data.model.*
 import retrofit2.Response
-import retrofit2.http.*
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.POST
+import retrofit2.http.Query
 
 interface SupabaseApi {
 
-    // =========================
-    // SPESE (VIEW)
-    // =========================
-
-    @GET("rest/v1/v_spese")
+    @GET("exec")
     suspend fun getSpeseView(
-        @Query("select") select: String = "*",
-        @Query("order") order: String = "data.desc"
+        @Query("resource") resource: String = "spese"
     ): List<SpesaView>
 
-
-    // =========================
-    // CATEGORIE
-    // =========================
-
-    @GET("rest/v1/cfg_categorie")
+    @GET("exec")
     suspend fun getCategorie(
-        @Query("select") select: String = "*",
-        @Query("order") order: String = "ordine.asc"
+        @Query("resource") resource: String = "categorie"
     ): List<Categoria>
 
-
-    // =========================
-    // SOTTOCATEGORIE PER CATEGORIA
-    // (via tabella ponte)
-    // =========================
-
-    @GET("rest/v1/cfg_categoria_sottocategoria")
+    @GET("exec")
     suspend fun getSottocategorieByCategoria(
-        @Query("select")
-        select: String =
-            "ordine,sottocategoria:cfg_sottocategorie(id,nome,ordine,attiva)",
-
-        @Query("categoria_id")
-        categoriaFilter: String,
-
-        @Query("attiva")
-        attiva: String = "eq.true",
-
-        @Query("order")
-        order: String = "ordine.asc"
+        @Query("resource") resource: String = "sottocategorie",
+        @Query("categoria_id") categoriaFilter: String
     ): List<LinkSottoRow>
 
-
-    // =========================
-    // RESOLVE categoria_link_id
-    // =========================
-
-    @GET("rest/v1/cfg_categoria_sottocategoria")
+    @GET("exec")
     suspend fun resolveCategoriaLinkId(
-        @Query("select")
-        select: String = "id",
-
-        @Query("categoria_id")
-        categoriaFilter: String,
-
-        @Query("sottocategoria_id")
-        sottocategoriaFilter: String,
-
-        @Query("limit")
-        limit: Int = 1
+        @Query("resource") resource: String = "categoria_link",
+        @Query("categoria_id") categoriaFilter: String,
+        @Query("sottocategoria_id") sottocategoriaFilter: String?
     ): List<LinkIdRow>
 
-
-    // =========================
-    // INSERT
-    // =========================
-
-    @POST("rest/v1/spese")
+    @POST("exec")
     suspend fun insertSpesa(
-        @Body spesa: SpesaUpsert
-    ): Response<Unit>
+        @Body spesa: SpesaUpsertRequest
+    ): Response<InsertSpesaResponse>
 
-
-    // =========================
-    // UPDATE (PATCH)
-    // =========================
-    // IMPORTANTE: usare @Query e non @Path
-
-    @PATCH("rest/v1/spese")
+    @POST("exec")
     suspend fun updateSpesa(
-        @Query("id") idFilter: String,
-        @Body spesa: SpesaUpsert
+        @Body req: UpdateSpesaRequest
     ): Response<Unit>
 
-
-    // =========================
-    // DELETE
-    // =========================
-
-    @DELETE("rest/v1/spese")
+    @POST("exec")
     suspend fun deleteSpesa(
-        @Query("id") idFilter: String
+        @Body req: DeleteSpesaRequest
     ): Response<Unit>
-
-    @POST("rest/v1/rpc/insert_spesa_first_free_id")
-    suspend fun insertSpesaFirstFreeId(
-        @Body req: RpcInsertSpesaRequest
-    ): retrofit2.Response<SpesaRow>
 }

--- a/app/src/main/java/com/emanuele/gestionespese/data/remote/SupabaseAuthInterceptor.kt
+++ b/app/src/main/java/com/emanuele/gestionespese/data/remote/SupabaseAuthInterceptor.kt
@@ -5,11 +5,16 @@ import okhttp3.Response
 
 class SupabaseAuthInterceptor(private val apiKey: String) : Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response {
-        val request = chain.request().newBuilder()
-            .addHeader("apikey", apiKey)
-            .addHeader("Authorization", "Bearer $apiKey")
+        val original = chain.request()
+        val url = original.url.newBuilder()
+            .addQueryParameter("key", apiKey)
+            .build()
+
+        val request = original.newBuilder()
+            .url(url)
             .addHeader("Content-Type", "application/json")
             .build()
+
         return chain.proceed(request)
     }
 }

--- a/app/src/main/java/com/emanuele/gestionespese/data/repo/SpeseRepository.kt
+++ b/app/src/main/java/com/emanuele/gestionespese/data/repo/SpeseRepository.kt
@@ -1,61 +1,76 @@
 package com.emanuele.gestionespese.data.repo
 
-import com.emanuele.gestionespese.data.model.*
+import com.emanuele.gestionespese.data.model.DeleteSpesaRequest
+import com.emanuele.gestionespese.data.model.SpesaUpsert
+import com.emanuele.gestionespese.data.model.SpesaUpsertRequest
+import com.emanuele.gestionespese.data.model.UpdateSpesaRequest
 import com.emanuele.gestionespese.data.remote.SupabaseApi
 import retrofit2.HttpException
 
-
 class SpeseRepository(private val api: SupabaseApi) {
 
-    // VIEW
-    suspend fun list(): List<SpesaView> =
-        api.getSpeseView()
+    suspend fun list() = api.getSpeseView()
 
-    // LOOKUP
-    suspend fun listCategorie(): List<Categoria> =
-        api.getCategorie()
+    suspend fun listCategorie() = api.getCategorie()
 
-    suspend fun listSottocategorie(categoriaId: String): List<Sottocategoria> =
-        api.getSottocategorieByCategoria(categoriaFilter = "eq.$categoriaId")
+    suspend fun listSottocategorie(categoriaId: String) =
+        api.getSottocategorieByCategoria(categoriaFilter = categoriaId)
             .mapNotNull { it.sottocategoria }
 
-    // INSERT
     suspend fun add(spesa: SpesaUpsert) {
-        val response = api.insertSpesa(spesa)
+        val (categoria, sottocategoria) = splitLinkId(spesa.categoriaLinkId)
+        val response = api.insertSpesa(
+            SpesaUpsertRequest(
+                contoId = spesa.metodoPagamento,
+                data = spesa.data,
+                importo = spesa.importo,
+                tipo = spesa.tipo,
+                categoria = categoria,
+                sottocategoria = sottocategoria,
+                descrizione = spesa.note
+            )
+        )
         if (!response.isSuccessful) {
             val body = response.errorBody()?.string()
             throw IllegalStateException("INSERT failed ${response.code()} - $body")
         }
     }
 
-    // UPDATE
     suspend fun update(id: Int, spesa: SpesaUpsert) {
-        val response = api.updateSpesa("eq.$id", spesa)
+        val (categoria, sottocategoria) = splitLinkId(spesa.categoriaLinkId)
+        val response = api.updateSpesa(
+            UpdateSpesaRequest(
+                id = id,
+                contoId = spesa.metodoPagamento,
+                data = spesa.data,
+                importo = spesa.importo,
+                tipo = spesa.tipo,
+                categoria = categoria,
+                sottocategoria = sottocategoria,
+                descrizione = spesa.note
+            )
+        )
         if (!response.isSuccessful) throw HttpException(response)
     }
 
-    // DELETE
     suspend fun delete(id: Int) {
-        val response = api.deleteSpesa("eq.$id")
+        val response = api.deleteSpesa(DeleteSpesaRequest(id = id))
         if (!response.isSuccessful) throw HttpException(response)
     }
 
-    // RESOLVE
     suspend fun resolveCategoriaLinkId(categoriaId: String, sottocategoriaId: String?): String {
-        val subFilter = if (sottocategoriaId == null) "is.null" else "eq.$sottocategoriaId"
         val rows = api.resolveCategoriaLinkId(
-            categoriaFilter = "eq.$categoriaId",
-            sottocategoriaFilter = subFilter
+            categoriaFilter = categoriaId,
+            sottocategoriaFilter = sottocategoriaId
         )
         return rows.firstOrNull()?.id
             ?: throw IllegalStateException("Nessun categoria_link_id trovato per categoria=$categoriaId sottocategoria=$sottocategoriaId")
     }
 
-    suspend fun addViaRpc(req: RpcInsertSpesaRequest) {
-        val resp = api.insertSpesaFirstFreeId(req)
-        if (!resp.isSuccessful) {
-            val body = resp.errorBody()?.string()
-            throw IllegalStateException("RPC INSERT failed ${resp.code()} - $body")
-        }
+    private fun splitLinkId(linkId: String): Pair<String, String> {
+        val parts = linkId.split("|", limit = 2)
+        val categoria = parts.getOrNull(0).orEmpty()
+        val sottocategoria = parts.getOrNull(1).orEmpty()
+        return categoria to sottocategoria
     }
 }

--- a/app/src/main/java/com/emanuele/gestionespese/ui/viewmodel/SpeseViewModel.kt
+++ b/app/src/main/java/com/emanuele/gestionespese/ui/viewmodel/SpeseViewModel.kt
@@ -3,7 +3,6 @@ package com.emanuele.gestionespese.ui.viewmodel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.emanuele.gestionespese.data.model.Categoria
-import com.emanuele.gestionespese.data.model.RpcInsertSpesaRequest
 import com.emanuele.gestionespese.data.model.Sottocategoria
 import com.emanuele.gestionespese.data.model.SpesaUpsert
 import com.emanuele.gestionespese.data.model.SpesaView
@@ -192,18 +191,17 @@ class SpeseViewModel(private val repo: SpeseRepository) : ViewModel() {
                 val mese = data.substring(5, 7).toInt()
 
                 if (editingId == null) {
-                    // INSERT via RPC: ID “primo disponibile” lo assegna il DB
-                    val req = RpcInsertSpesaRequest(
+                    val payload = SpesaUpsert(
                         data = data,
-                        descrizione = descrizione,
                         importo = importo,
                         tipo = tipo,
                         mese = mese,
                         anno = anno,
+                        categoriaLinkId = linkId,
                         metodoPagamento = metodoPagamento,
-                        categoriaLinkId = linkId
+                        note = descrizione
                     )
-                    repo.addViaRpc(req)
+                    repo.add(payload)
                 } else {
                     // UPDATE classico: qui l’ID esiste già
                     val payload = SpesaUpsert(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
     <string name="app_name">Gestione Spese</string>
-    <string name="supabase_url">https://fkeihvmzcfaguvevtwlw.supabase.co</string>
-    <string name="supabase_anon_key">sb_publishable_gGF-cA5u_jeqIJOypNKtTQ_QiCRzDfl</string>
+    <string name="backend_url">https://script.google.com/macros/s/AKfycbxFS-cyDZ_z439zPhpDRyjTJdzMxxLha_gbbt5mdPeMPdRc4ZuZ6G8c5uhKacZxtbeH/</string>
+    <string name="backend_api_key">9c7f3e2a6b8d4f1c0e9a7b6d5c4f3a2b</string>
 </resources>

--- a/docs/google-apps-script.gs
+++ b/docs/google-apps-script.gs
@@ -1,0 +1,256 @@
+const API_KEY = "9c7f3e2a6b8d4f1c0e9a7b6d5c4f3a2b";
+
+function doGet(e) {
+  try {
+    checkKey_(e);
+    const p = e.parameter || {};
+    const resource = String(p.resource || "").toLowerCase();
+
+    if (resource === "spese") return json_(listSpese_());
+    if (resource === "spesa") {
+      const id = String(p.id || "").trim();
+      if (!id) return json_({ error: "Missing id" }, 400);
+      return json_({ data: getSpesaById_(id) });
+    }
+    if (resource === "categorie") return json_(listCategorie_());
+    if (resource === "sottocategorie") {
+      const categoriaId = String(p.categoria_id || "").trim();
+      return json_(listSottocategorie_(categoriaId));
+    }
+    if (resource === "categoria_link") {
+      const categoriaId = String(p.categoria_id || "").trim();
+      const sottocategoriaId = String(p.sottocategoria_id || "").trim();
+      return json_(resolveCategoriaLinkId_(categoriaId, sottocategoriaId));
+    }
+
+    return json_({ error: "Unknown resource" }, 404);
+  } catch (err) {
+    return json_({ error: String(err && err.message ? err.message : err) }, 500);
+  }
+}
+
+function doPost(e) {
+  try {
+    checkKey_(e);
+    const body = parseJsonBody_(e);
+    const resource = String(body.resource || "").toLowerCase();
+
+    if (resource === "utente") {
+      const user = String(body.user || "").trim();
+      const password = String(body.password || "").trim();
+      if (!user) return json_({ error: "Missing user" }, 400);
+      if (!password) return json_({ error: "Missing password" }, 400);
+      return json_({ data: getUtenteByUser_(user, password) });
+    }
+
+    if (resource === "spese_batch") {
+      const rows = body.rows || [];
+      const saved = rows.map(insertSpesa_);
+      return json_({ ok: true, saved });
+    }
+
+    if (resource === "spesa") return json_(insertSpesa_(body));
+    if (resource === "spesa_update") return json_(updateSpesa_(body));
+    if (resource === "spesa_delete") return json_(deleteSpesa_(body));
+
+    return json_({ error: "Unknown resource" }, 404);
+  } catch (err) {
+    return json_({ error: String(err && err.message ? err.message : err) }, 500);
+  }
+}
+
+function checkKey_(e) {
+  const key = (e && e.parameter && e.parameter.key) ? String(e.parameter.key) : "";
+  if (key !== API_KEY) throw new Error("Unauthorized");
+}
+
+function parseJsonBody_(e) {
+  if (!e || !e.postData || !e.postData.contents) throw new Error("Missing body");
+  return JSON.parse(e.postData.contents);
+}
+
+function json_(obj) {
+  return ContentService.createTextOutput(JSON.stringify(obj)).setMimeType(ContentService.MimeType.JSON);
+}
+
+function getSheet_(name) {
+  const sh = SpreadsheetApp.getActive().getSheetByName(name);
+  if (!sh) throw new Error("Sheet " + name + " not found");
+  return sh;
+}
+
+function listSpese_() {
+  const sh = getSheet_("SPESE");
+  const last = sh.getLastRow();
+  if (last < 2) return [];
+
+  const rows = sh.getRange(2, 1, last - 1, 11).getValues();
+  return rows.map(r => ({
+    id: Number(r[0]),
+    utente_id: String(r[1] || ""),
+    data: toIsoDate_(r[2]),
+    conto_id: String(r[3] || ""),
+    importo: Number(r[4] || 0),
+    tipo: String(r[5] || ""),
+    categoria_link_id: String(r[6] || ""),
+    categoria_id: String(r[6] || ""),
+    categoria: String(r[6] || ""),
+    sottocategoria_id: String(r[7] || ""),
+    sottocategoria: String(r[7] || ""),
+    descrizione: String(r[8] || ""),
+    mese: Number(r[9] || 0),
+    anno: Number(r[10] || 0),
+    metodo_pagamento: String(r[3] || "")
+  }));
+}
+
+function listCategorie_() {
+  const sh = getSheet_("CATEGORIE");
+  const last = sh.getLastRow();
+  if (last < 2) return [];
+  const rows = sh.getRange(2, 1, last - 1, 3).getValues();
+  return rows.map(r => ({ id: String(r[0] || ""), nome: String(r[1] || ""), ordine: Number(r[2] || 0), attiva: true }));
+}
+
+function listSottocategorie_(categoriaId) {
+  const sh = getSheet_("SOTTOCATEGORIE");
+  const last = sh.getLastRow();
+  if (last < 2) return [];
+  const rows = sh.getRange(2, 1, last - 1, 4).getValues();
+  return rows
+    .filter(r => !categoriaId || String(r[1] || "") === categoriaId)
+    .map(r => ({
+      ordine: Number(r[3] || 0),
+      sottocategoria: { id: String(r[0] || ""), nome: String(r[2] || ""), ordine: Number(r[3] || 0), attiva: true }
+    }));
+}
+
+function resolveCategoriaLinkId_(categoriaId, sottocategoriaId) {
+  if (!categoriaId) return [];
+  const id = sottocategoriaId ? categoriaId + "|" + sottocategoriaId : categoriaId;
+  return [{ id }];
+}
+
+function getUtenteByUser_(utente, password) {
+  const sh = getSheet_("UTENTE");
+  const last = sh.getLastRow();
+  if (last < 2) return null;
+  const values = sh.getRange(2, 1, last - 1, 11).getValues();
+
+  for (const r of values) {
+    if (String(r[1] || "").trim() === utente && String(r[2] || "").trim() === password) {
+      return { id: r[0], utente: r[1], password: r[2], nome: r[3], cognome: r[4], attivo: r[5], email: r[6] };
+    }
+  }
+  return null;
+}
+
+function getSpesaById_(id) {
+  const sh = getSheet_("SPESE");
+  const last = sh.getLastRow();
+  if (last < 2) return null;
+  const values = sh.getRange(2, 1, last - 1, 11).getValues();
+
+  for (const r of values) {
+    if (String(r[0] || "").trim() === id) {
+      return {
+        id: r[0],
+        utente_id: r[1],
+        data: toIsoDate_(r[2]),
+        conto_id: r[3],
+        importo: r[4],
+        tipo: r[5],
+        categoria: r[6],
+        sottocategoria: r[7],
+        descrizione: r[8],
+        mese: r[9],
+        anno: r[10]
+      };
+    }
+  }
+  return null;
+}
+
+function insertSpesa_(body) {
+  const sh = getSheet_("SPESE");
+  const utenteId = String(body.utente_id || "").trim();
+  const contoId = String(body.conto_id || body.metodo_pagamento || "").trim();
+  const tipo = String(body.tipo || "").trim();
+  const categoria = String(body.categoria || body.categoria_link_id || "").trim();
+  const sottocategoria = String(body.sottocategoria || body.sottocategoria_id || "").trim();
+  const descr = String(body.descrizione || body.note || "").trim();
+  const importo = Number(body.importo);
+  const dataStr = String(body.data || "").trim();
+
+  if (!utenteId || !contoId || !dataStr || !Number.isFinite(importo)) {
+    throw new Error("Missing/invalid fields (utente_id, conto_id, data, importo)");
+  }
+
+  const m = dataStr.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (!m) throw new Error("Invalid date format. Expected YYYY-MM-DD");
+
+  const year = Number(m[1]);
+  const month = Number(m[2]);
+  const day = Number(m[3]);
+  const dataObj = new Date(year, month - 1, day);
+  const newId = nextId_(sh, 1);
+
+  sh.appendRow([newId, utenteId, dataObj, contoId, importo, tipo, categoria, sottocategoria, descr, month, year]);
+  return { id: newId };
+}
+
+function updateSpesa_(body) {
+  const sh = getSheet_("SPESE");
+  const id = Number(body.id);
+  if (!Number.isFinite(id)) throw new Error("Missing id");
+
+  const all = sh.getRange(2, 1, Math.max(sh.getLastRow() - 1, 0), 11).getValues();
+  const idx = all.findIndex(r => Number(r[0]) === id);
+  if (idx < 0) throw new Error("Spesa not found");
+
+  const rowNumber = idx + 2;
+  const m = String(body.data || "").match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (!m) throw new Error("Invalid date format. Expected YYYY-MM-DD");
+  const year = Number(m[1]);
+  const month = Number(m[2]);
+  const day = Number(m[3]);
+
+  sh.getRange(rowNumber, 3, 1, 9).setValues([[
+    new Date(year, month - 1, day),
+    String(body.conto_id || ""),
+    Number(body.importo || 0),
+    String(body.tipo || ""),
+    String(body.categoria || ""),
+    String(body.sottocategoria || ""),
+    String(body.descrizione || ""),
+    month,
+    year
+  ]]);
+
+  return { ok: true };
+}
+
+function deleteSpesa_(body) {
+  const sh = getSheet_("SPESE");
+  const id = Number(body.id);
+  if (!Number.isFinite(id)) throw new Error("Missing id");
+
+  const all = sh.getRange(2, 1, Math.max(sh.getLastRow() - 1, 0), 1).getValues().flat();
+  const idx = all.findIndex(v => Number(v) === id);
+  if (idx < 0) throw new Error("Spesa not found");
+  sh.deleteRow(idx + 2);
+  return { ok: true };
+}
+
+function nextId_(sheet, idCol) {
+  const last = sheet.getLastRow();
+  if (last < 2) return 1;
+  const ids = sheet.getRange(2, idCol, last - 1, 1).getValues().flat();
+  return Math.max(0, ...ids.map(v => Number(v) || 0)) + 1;
+}
+
+function toIsoDate_(value) {
+  const d = value instanceof Date ? value : new Date(value);
+  if (isNaN(d.getTime())) return "";
+  return Utilities.formatDate(d, Session.getScriptTimeZone(), "yyyy-MM-dd");
+}

--- a/docs/migrazione-backend.md
+++ b/docs/migrazione-backend.md
@@ -1,0 +1,49 @@
+# Migrazione backend: da Supabase a Google Apps Script
+
+## Dove cambiare il reperimento dati nell'app
+
+I punti chiave sono:
+
+1. `app/src/main/res/values/strings.xml`
+   - `backend_url`: endpoint base del Web App Apps Script.
+   - `backend_api_key`: chiave usata come query param `?key=...`.
+
+2. `app/src/main/java/com/emanuele/gestionespese/data/remote/SupabaseApi.kt`
+   - Tutti i metodi Retrofit ora puntano a `exec` con query `resource=...`.
+
+3. `app/src/main/java/com/emanuele/gestionespese/data/remote/SupabaseAuthInterceptor.kt`
+   - Aggiunge automaticamente `key=<api_key>` a ogni chiamata.
+
+4. `app/src/main/java/com/emanuele/gestionespese/data/repo/SpeseRepository.kt`
+   - Mapping tra modello app e payload Apps Script.
+   - Alias tra vecchi nomi Supabase e nuove colonne foglio.
+
+5. `docs/google-apps-script.gs`
+   - Script completo da incollare in Apps Script.
+   - Espone metodi GET/POST per lista, dettaglio, categorie, sottocategorie, insert, update, delete.
+
+## Flusso Git consigliato per la nuova versione
+
+```bash
+git checkout -b feat/migrazione-apps-script
+# fai modifiche
+git add .
+git commit -m "feat: migra backend da supabase a google apps script"
+git push -u origin feat/migrazione-apps-script
+```
+
+Poi apri PR verso il branch principale (`main` o `master`).
+
+## Strategia alias colonne
+
+Per ridurre impatti sul codice UI:
+
+- In lettura spese, lo script restituisce sia campi “nuovi” che alias compatibili (`categoria_link_id`, `categoria_id`, `metodo_pagamento`, ecc.).
+- Nell'app, `SpesaView` usa `@SerializedName(..., alternate = [...])` così accetta più nomi senza rompere schermate esistenti.
+
+## Deploy Apps Script
+
+1. Apri progetto Apps Script.
+2. Incolla `docs/google-apps-script.gs` nel file `.gs` principale.
+3. **Deploy > Manage deployments > Edit > New version > Deploy**.
+4. Verifica endpoint `/exec` e usa la stessa `API_KEY` anche nell'app Android.


### PR DESCRIPTION
### Motivation
- Spostare il backend dell'app da Supabase a un endpoint Google Apps Script per poter scrivere direttamente su un file Google Sheets tramite uno script Apps Script.
- Minimizzare l'impatto sull'interfaccia e sul codice esistente applicando alias/compatibilità sui campi JSON e mantenendo i nomi delle classi usate dall'app.
- Fornire uno script Apps Script di riferimento e una guida di migrazione per permettere deploy e testing rapidi del nuovo backend.

### Description
- Retrofit `SupabaseApi` è stato aggiornato per chiamare l'endpoint `exec` con il parametro `resource=...` e sono stati introdotti nuovi modelli request/response per il payload Apps Script (`SpesaUpsertRequest`, `UpdateSpesaRequest`, `DeleteSpesaRequest`, `InsertSpesaResponse`).
- L'interceptor `SupabaseAuthInterceptor` ora aggiunge automaticamente la query `key=<api>` e `app/src/main/res/values/strings.xml` è stato aggiornato con `backend_url` e `backend_api_key` per puntare all'Apps Script fornito.
- `SpeseRepository` e `SpeseViewModel` sono stati adattati per mappare i modelli dell'app ai payload dello script (incluso `splitLinkId` per separare `categoria|sottocategoria`) ed è stato rimosso il percorso di insert RPC specifico di Supabase.
- Aggiunti `docs/google-apps-script.gs` (implementazione completa GET/POST con alias dei campi, insert/update/delete/batch) e `docs/migrazione-backend.md` con istruzioni di deploy e suggerimenti Git.

### Testing
- Ho eseguito un tentativo di compilazione con `./gradlew :app:compileDebugKotlin`, che è fallito per limiti dell'ambiente (Android/SDK/tooling error `25.0.1`).
- Non sono stati eseguiti altri test automatizzati in CI; le modifiche sono state validate tramite editing locale dei file e il tentativo di build descritto sopra.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2bf30906c8322beb8d97137628f5c)