### PR TITLE
Change workflow to build and release APK

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,23 +1,30 @@
-name: "CI + CodeQL"
+name: "Build & Release APK"
 
 on:
   push:
-    branches: [ "master", "main", "feature/**" ]
+    branches: [ "master", "main" ]
   pull_request:
     branches: [ "master", "main" ]
-  schedule:
-    - cron: '33 0 * * 0'
+  workflow_dispatch:
 
 jobs:
-
-  # ── BUILD + TEST ──────────────────────────────────────────────────────
   build:
-    name: Build & Test
+    name: Build Debug APK
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: read
 
     steps:
-      - name: Checkout
+      - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Read version
+        id: version
+        run: |
+          VERSION=$(cat version.txt | tr -d '[:space:]')
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Version: $VERSION"
 
       - name: Setup JDK 17
         uses: actions/setup-java@v4
@@ -26,7 +33,6 @@ jobs:
           distribution: 'temurin'
           cache: gradle
 
-      # Crea google-services.json da GitHub Secret
       - name: Create google-services.json
         run: echo '${{ secrets.GOOGLE_SERVICES_JSON }}' > app/google-services.json
 
@@ -36,54 +42,80 @@ jobs:
       - name: Build Debug APK
         run: ./gradlew assembleDebug --no-daemon
 
-      - name: Run Unit Tests
-        run: ./gradlew testDebugUnitTest --no-daemon
+      - name: Rename APK with version
+        run: |
+          mv app/build/outputs/apk/debug/app-debug.apk \
+             app/build/outputs/apk/debug/GestioneSpese-v${{ steps.version.outputs.version }}.apk
 
-  # ── CODEQL SECURITY ANALYSIS ─────────────────────────────────────────
-  analyze:
-    name: CodeQL Security Analysis
-    runs-on: ubuntu-latest
-    needs: build   # gira solo se il build passa
-    permissions:
-      security-events: write
-      packages: read
-      actions: read
-      contents: read
-
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - language: java-kotlin
-            build-mode: manual   # ← manual per avere controllo sul build
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup JDK 17
-        uses: actions/setup-java@v4
+      - name: Upload APK as artifact
+        uses: actions/upload-artifact@v4
         with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: gradle
+          name: GestioneSpese-v${{ steps.version.outputs.version }}-${{ github.sha }}
+          path: app/build/outputs/apk/debug/GestioneSpese-v${{ steps.version.outputs.version }}.apk
+          retention-days: 30
 
-      - name: Create google-services.json
-        run: echo '${{ secrets.GOOGLE_SERVICES_JSON }}' > app/google-services.json
+      - name: Get short SHA
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main')
+        id: slug
+        run: echo "sha7=$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_OUTPUT
 
-      - name: Grant execute permission to gradlew
-        run: chmod +x gradlew
+      - name: Get changed files summary
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main')
+        id: changes
+        run: |
+          CHANGED=$(git diff --name-only HEAD~1 HEAD 2>/dev/null | head -20 | sed 's/^/- /' || echo "- Prima release")
+          echo "files<<EOF" >> $GITHUB_OUTPUT
+          echo "$CHANGED" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
 
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+      - name: Create versioned GitHub Release
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main')
+        uses: softprops/action-gh-release@v2
         with:
-          languages: ${{ matrix.language }}
-          build-mode: ${{ matrix.build-mode }}
+          tag_name: v${{ steps.version.outputs.version }}-${{ steps.slug.outputs.sha7 }}
+          name: "Gestione Spese v${{ steps.version.outputs.version }}"
+          body: |
+            ## 📱 Gestione Spese v${{ steps.version.outputs.version }}
 
-      - name: Build for CodeQL
-        run: ./gradlew assembleDebug --no-daemon
+            ### 📦 Installazione
+            1. Scarica il file `GestioneSpese-v${{ steps.version.outputs.version }}.apk`
+            2. Abilita **"Installa da fonti sconosciute"** nelle impostazioni Android
+            3. Apri il file e installa
 
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+            ### 🔧 Dettagli build
+            | | |
+            |---|---|
+            | **Versione** | v${{ steps.version.outputs.version }} |
+            | **Commit** | `${{ steps.slug.outputs.sha7 }}` |
+            | **Data** | ${{ github.event.head_commit.timestamp }} |
+            | **Branch** | `master` |
+
+            ### 📝 Commit
+            > ${{ github.event.head_commit.message }}
+
+            ### 📂 File modificati
+            ${{ steps.changes.outputs.files }}
+
+            ---
+            > ⚠️ Questa è una build di **debug** — non per distribuzione pubblica.
+          files: app/build/outputs/apk/debug/GestioneSpese-v${{ steps.version.outputs.version }}.apk
+          draft: false
+          prerelease: false
+          make_latest: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update latest tag
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main')
+        uses: softprops/action-gh-release@v2
         with:
-          category: "/language:${{matrix.language}}"
+          tag_name: latest
+          name: "Latest — v${{ steps.version.outputs.version }}"
+          body: |
+            Ultima build stabile — **v${{ steps.version.outputs.version }}**
+            Aggiornato automaticamente ad ogni push su master.
+          files: app/build/outputs/apk/debug/GestioneSpese-v${{ steps.version.outputs.version }}.apk
+          draft: false
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Updated the GitHub Actions workflow to build and release an APK instead of performing CodeQL analysis. Added steps for versioning and uploading the APK as an artifact.